### PR TITLE
Fix Duplicated Public Specifier Warning

### DIFF
--- a/SafeAreaInputAccessoryViewWrapperView/Classes/SafeAreaInputAccessoryViewWrapperView.swift
+++ b/SafeAreaInputAccessoryViewWrapperView/Classes/SafeAreaInputAccessoryViewWrapperView.swift
@@ -82,7 +82,7 @@ public extension SafeAreaInputAccessoryViewWrapperView {
     /// NOTE: This is not used internally, but rather, it's a convenience helper for views that
     /// might need to adjust their constraints or insets based on this size.
     /// This will also work when changing the size of the application window due to iPad Multitasking.
-    public func computedSize() -> CGSize {
+    func computedSize() -> CGSize {
         return systemLayoutSizeFitting(CGSize(width: UIApplication.shared.keyWindow?.bounds.width ?? UIScreen.main.bounds.width,
                                               height: .greatestFiniteMagnitude),
                                        withHorizontalFittingPriority: .required,


### PR DESCRIPTION
# Description
This PR removes the `public` specifer from the `computedSize()` method since the extension that it's in is already specified as `public`. Not a huge change but it removes the single warning being broadcast from this pod. 